### PR TITLE
fix: rename crypto key

### DIFF
--- a/4-projects/modules/composer_env/crypto.tf
+++ b/4-projects/modules/composer_env/crypto.tf
@@ -53,7 +53,7 @@ resource "google_project_service_identity" "service_agents_kms" {
 }
 
 resource "google_kms_crypto_key_iam_member" "app_key" {
-  for_each      = module.app_cloudbuild_project.crypto_key
+  for_each      = module.app_cloudbuild_project.kms_keys
   crypto_key_id = each.value.id
   role          = "roles/cloudkms.admin"
   member        = "serviceAccount:${local.app_infra_pipeline_service_accounts[var.repo_name]}"
@@ -61,7 +61,7 @@ resource "google_kms_crypto_key_iam_member" "app_key" {
 
 // Add Secret Manager Service Agent to key with encrypt/decrypt permissions
 resource "google_kms_crypto_key_iam_binding" "secretmanager_agent" {
-  for_each      = module.app_cloudbuild_project.crypto_key
+  for_each      = module.app_cloudbuild_project.kms_keys
   crypto_key_id = each.value.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   members       = local.kms_secret_sa_accounts

--- a/4-projects/modules/composer_env/outputs.tf
+++ b/4-projects/modules/composer_env/outputs.tf
@@ -36,7 +36,7 @@ output "project_sa" {
 
 output "project_crypto_key" {
   description = "key created in project"
-  value       = module.app_cloudbuild_project.crypto_key
+  value       = module.app_cloudbuild_project.kms_keys
 }
 
 # output "terraform_service_accounts" {


### PR DESCRIPTION
 * Rename object, crypto key object does not exists and causes the `terraform validate` command to fail. This PR renames it to kms, which is the existing object