### PR TITLE
fix: replace references to terraform-example-foundation repository with references to the terraform-google-enterprise-genai repository

### DIFF
--- a/0-bootstrap/README-GitHub.md
+++ b/0-bootstrap/README-GitHub.md
@@ -61,13 +61,13 @@ for each one of the repositories.
 
 ### Deploying step 0-bootstrap
 
-1. Clone [terraform-example-foundation](https://github.com/terraform-google-modules/terraform-example-foundation) into your local environment.
+1. Clone [terraform-google-enterprise-genai](https://github.com/terraform-google-modules/terraform-google-enterprise-genai) into your local environment.
 
    ```bash
-   git clone https://github.com/terraform-google-modules/terraform-example-foundation.git
+   git clone https://github.com/terraform-google-modules/terraform-google-enterprise-genai.git
    ```
 
-1. Clone the private repository you created to host the `0-bootstrap` terraform configuration at the same level of the `terraform-example-foundation` folder.
+1. Clone the private repository you created to host the `0-bootstrap` terraform configuration at the same level of the `terraform-google-enterprise-genai` folder.
 You must be [authenticated to GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github).
 
    ```bash
@@ -78,7 +78,7 @@ You must be [authenticated to GitHub](https://docs.github.com/en/authentication/
 
    ```bash
    gcp-bootstrap/
-   terraform-example-foundation/
+   terraform-google-enterprise-genai/
    ```
 
 1. Navigate into the repo. All subsequent
@@ -110,11 +110,11 @@ You must be [authenticated to GitHub](https://docs.github.com/en/authentication/
    ```bash
    mkdir -p envs/shared
 
-   cp -RT ../terraform-example-foundation/0-bootstrap/ ./envs/shared
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
+   cp -RT ../terraform-google-enterprise-genai/0-bootstrap/ ./envs/shared
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
    mkdir -p .github/workflows
-   cp ../terraform-example-foundation/build/github-tf-* ./.github/workflows/
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp ../terraform-google-enterprise-genai/build/github-tf-* ./.github/workflows/
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    cd ./envs/shared
    ```
@@ -153,7 +153,7 @@ export the GitHub fine grained access token as an environment variable:
 1. Use the helper script [validate-requirements.sh](../scripts/validate-requirements.sh) to validate your environment:
 
    ```bash
-   ../../../terraform-example-foundation/scripts/validate-requirements.sh  -o <ORGANIZATION_ID> -b <BILLING_ACCOUNT_ID> -u <END_USER_EMAIL> -e
+   ../../../terraform-google-enterprise-genai/scripts/validate-requirements.sh  -o <ORGANIZATION_ID> -b <BILLING_ACCOUNT_ID> -u <END_USER_EMAIL> -e
    ```
 
    **Note:** The script is not able to validate if the user is in a Cloud Identity or Google Workspace group with the required roles.
@@ -249,7 +249,7 @@ we recommend that you request 50 additional projects for the **projects step ser
 
 ## Deploying step 1-org
 
-1. Clone the repository you created to host the `1-org` terraform configuration at the same level of the `terraform-example-foundation` folder.
+1. Clone the repository you created to host the `1-org` terraform configuration at the same level of the `terraform-google-enterprise-genai` folder.
 
    ```bash
    git clone git@github.com:<GITHUB-OWNER>/<GITHUB-ORGANIZATION-REPO>.git gcp-org
@@ -281,11 +281,11 @@ we recommend that you request 50 additional projects for the **projects step ser
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/1-org/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
+   cp -RT ../terraform-google-enterprise-genai/1-org/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
    mkdir -p .github/workflows
-   cp ../terraform-example-foundation/build/github-tf-* ./.github/workflows/
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp ../terraform-google-enterprise-genai/build/github-tf-* ./.github/workflows/
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -365,7 +365,7 @@ See the shared folder [README.md](../1-org/envs/shared/README.md#inputs) for add
 
 ## Deploying step 2-environments
 
-1. Clone the repository you created to host the `2-environments` terraform configuration at the same level of the `terraform-example-foundation` folder.
+1. Clone the repository you created to host the `2-environments` terraform configuration at the same level of the `terraform-google-enterprise-genai` folder.
 
    ```bash
    git clone git@github.com:<GITHUB-OWNER>/<GITHUB-ENVIRONMENTS-REPO>.git gcp-environments
@@ -404,11 +404,11 @@ See the shared folder [README.md](../1-org/envs/shared/README.md#inputs) for add
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/2-environments/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
+   cp -RT ../terraform-google-enterprise-genai/2-environments/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
    mkdir -p .github/workflows
-   cp ../terraform-example-foundation/build/github-tf-* ./.github/workflows/
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp ../terraform-google-enterprise-genai/build/github-tf-* ./.github/workflows/
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -472,7 +472,7 @@ or go to [Deploying step 3-networks-hub-and-spoke](#deploying-step-3-networks-hu
 
 ## Deploying step 3-networks-dual-svpc
 
-1. Clone the repository you created to host the `3-networks-dual-svpc` terraform configuration at the same level of the `terraform-example-foundation` folder.
+1. Clone the repository you created to host the `3-networks-dual-svpc` terraform configuration at the same level of the `terraform-google-enterprise-genai` folder.
 
    ```bash
    git clone git@github.com:<GITHUB-OWNER>/<GITHUB-NETWORKS-REPO>.git gcp-networks
@@ -510,11 +510,11 @@ or go to [Deploying step 3-networks-hub-and-spoke](#deploying-step-3-networks-hu
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/3-networks-dual-svpc/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
+   cp -RT ../terraform-google-enterprise-genai/3-networks-dual-svpc/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
    mkdir -p .github/workflows
-   cp ../terraform-example-foundation/build/github-tf-* ./.github/workflows/
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp ../terraform-google-enterprise-genai/build/github-tf-* ./.github/workflows/
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -635,7 +635,7 @@ An environment variable `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` will be set with th
 
 ## Deploying step 3-networks-hub-and-spoke
 
-1. Clone the repository you created to host the `3-networks-hub-and-spoke` terraform configuration at the same level of the `terraform-example-foundation` folder.
+1. Clone the repository you created to host the `3-networks-hub-and-spoke` terraform configuration at the same level of the `terraform-google-enterprise-genai` folder.
 
    ```bash
    git clone git@github.com:<GITHUB-OWNER>/<GITHUB-NETWORKS-REPO>.git gcp-networks
@@ -673,11 +673,11 @@ An environment variable `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` will be set with th
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/3-networks-hub-and-spoke/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
+   cp -RT ../terraform-google-enterprise-genai/3-networks-hub-and-spoke/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
    mkdir -p .github/workflows
-   cp ../terraform-example-foundation/build/github-tf-* ./.github/workflows/
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp ../terraform-google-enterprise-genai/build/github-tf-* ./.github/workflows/
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -786,7 +786,7 @@ An environment variable `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` will be set with th
 
 ## Deploying step 4-projects
 
-1. Clone the repository you created to host the `4-projects` terraform configuration at the same level of the `terraform-example-foundation` folder.
+1. Clone the repository you created to host the `4-projects` terraform configuration at the same level of the `terraform-google-enterprise-genai` folder.
 
    ```bash
    git clone git@github.com:<GITHUB-OWNER>/<GITHUB-PROJECTS-REPO>.git gcp-projects
@@ -825,11 +825,11 @@ An environment variable `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` will be set with th
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/4-projects/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
+   cp -RT ../terraform-google-enterprise-genai/4-projects/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
    mkdir -p .github/workflows
-   cp ../terraform-example-foundation/build/github-tf-* ./.github/workflows/
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp ../terraform-google-enterprise-genai/build/github-tf-* ./.github/workflows/
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 

--- a/0-bootstrap/README-Jenkins.md
+++ b/0-bootstrap/README-Jenkins.md
@@ -51,7 +51,7 @@ You arrived to these instructions because you are using the `jenkins_bootstrap` 
   - Access to the Jenkins Controller Web UI
   - [SSH Agent Jenkins plugin](https://plugins.jenkins.io/ssh-agent) installed in your Jenkins Controller
   - Private IP address for the Jenkins Agent: usually assigned by your network administrator. You will use this IP for the GCE instance that will be created in the `prj-b-cicd` GCP Project in step [II. Create the SEED and CI/CD projects using Terraform](#ii-create-the-seed-and-cicd-projects-using-terraform).
-  - Access to create five Git repositories, one for each directory in this [monorepo](https://github.com/terraform-google-modules/terraform-example-foundation) (`0-bootstrap, 1-org, 2-environments, 3-networks, 4-projects`). These are usually private repositories that might be on-prem.
+  - Access to create five Git repositories, one for each directory in this [monorepo](https://github.com/terraform-google-modules/terraform-google-enterprise-genai) (`0-bootstrap, 1-org, 2-environments, 3-networks, 4-projects`). These are usually private repositories that might be on-prem.
 
 1. Generate a SSH key pair. In the Jenkins Controller host, use the `ssh-keygen` command to generate a SSH key pair.
    - You will need this key pair to enable authentication between the Controller and Agent. Although the key pair can be generated in any linux machine, it is recommended not to copy the secret private key from one host to another, so you probably want to do this in the Jenkins Controller host command line.
@@ -78,7 +78,7 @@ You arrived to these instructions because you are using the `jenkins_bootstrap` 
    - Jenkins Agent’s private IP address (usually assigned by your Network Administrator. In the provided examples this IP is "172.16.1.6"). This private IP will be reachable through the VPN connection that you will create later.
 
 1. Create five individual Git repositories in your Git server (This might be a task delegated to your infrastructure team)
-   - Note that although this infrastructure code is distributed to you as a [monorepo](https://github.com/terraform-google-modules/terraform-example-foundation), you will store the code in five different repositories, one for each directory:
+   - Note that although this infrastructure code is distributed to you as a [monorepo](https://github.com/terraform-google-modules/terraform-google-enterprise-genai), you will store the code in five different repositories, one for each directory:
 
    ```text
    ./0-bootstrap
@@ -113,7 +113,7 @@ You arrived to these instructions because you are using the `jenkins_bootstrap` 
 1. Clone this mono-repository with:
 
    ```bash
-   git clone https://github.com/terraform-google-modules/terraform-example-foundation
+   git clone https://github.com/terraform-google-modules/terraform-google-enterprise-genai
    ```
 
 1. Clone the repository you created to host the `0-bootstrap` directory with:
@@ -132,7 +132,7 @@ You arrived to these instructions because you are using the `jenkins_bootstrap` 
 1. Copy contents of foundation to new repo (modify accordingly based on your current directory).
 
    ```bash
-   cp -RT ../terraform-example-foundation/0-bootstrap/ .
+   cp -RT ../terraform-google-enterprise-genai/0-bootstrap/ .
    ```
 
 1. Activate the Jenkins module and disable the Cloud Build module. This implies manually editing the following files:
@@ -313,10 +313,10 @@ Here you will configure a VPN Network tunnel to enable connectivity between the 
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/1-org/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
-   cp ../terraform-example-foundation/build/Jenkinsfile .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/1-org/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
+   cp ../terraform-google-enterprise-genai/build/Jenkinsfile .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -419,10 +419,10 @@ Here you will configure a VPN Network tunnel to enable connectivity between the 
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/2-environments/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
-   cp ../terraform-example-foundation/build/Jenkinsfile .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/2-environments/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
+   cp ../terraform-google-enterprise-genai/build/Jenkinsfile .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -525,10 +525,10 @@ Here you will configure a VPN Network tunnel to enable connectivity between the 
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/3-networks-dual-svpc/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
-   cp ../terraform-example-foundation/build/Jenkinsfile .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/3-networks-dual-svpc/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
+   cp ../terraform-google-enterprise-genai/build/Jenkinsfile .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -678,10 +678,10 @@ Here you will configure a VPN Network tunnel to enable connectivity between the 
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/3-networks-hub-and-spoke/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
-   cp ../terraform-example-foundation/build/Jenkinsfile .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/3-networks-hub-and-spoke/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
+   cp ../terraform-google-enterprise-genai/build/Jenkinsfile .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -831,10 +831,10 @@ Here you will configure a VPN Network tunnel to enable connectivity between the 
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/4-projects/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
-   cp ../terraform-example-foundation/build/Jenkinsfile .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/4-projects/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
+   cp ../terraform-google-enterprise-genai/build/Jenkinsfile .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 

--- a/0-bootstrap/README-Terraform-Cloud.md
+++ b/0-bootstrap/README-Terraform-Cloud.md
@@ -59,13 +59,13 @@ that are created, see the organization bootstrap module
 
 ### Instructions
 
-1. Clone [terraform-example-foundation](https://github.com/terraform-google-modules/terraform-example-foundation) into your local environment.
+1. Clone [terraform-google-enterprise-genai](https://github.com/terraform-google-modules/terraform-google-enterprise-genai) into your local environment.
 
    ```bash
-   git clone https://github.com/terraform-google-modules/terraform-example-foundation.git
+   git clone https://github.com/terraform-google-modules/terraform-google-enterprise-genai.git
    ```
 
-1. Clone all the private repositories (or projects) you created at the same level of the `terraform-example-foundation` folder.
+1. Clone all the private repositories (or projects) you created at the same level of the `terraform-google-enterprise-genai` folder.
 You must be authenticated to the VCS provider. See [GitHub authentication](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github) or [GitLab authentication](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github) for more details.
 
    ```bash
@@ -92,7 +92,7 @@ You must be authenticated to the VCS provider. See [GitHub authentication](https
    gcp-environments/
    gcp-networks/
    gcp-projects/
-   terraform-example-foundation/
+   terraform-google-enterprise-genai/
    ```
 
 1. In your VCS repositories (or projects) it is expected to have the following branches created. Also, these branches shouldn't be empty, you need at least a single file. Run `scripts/git_create_branches_helper.sh` script to create these branches with a seed file for each repository automatically.
@@ -104,8 +104,8 @@ You must be authenticated to the VCS provider. See [GitHub authentication](https
    - Note: `scripts/git_create_branches_helper.sh` script and the following commands assume you are running it from the directory that has all the repos cloned (layout described in the previous step). If you run from another directory, adjust the `BASE_PATH` variable at the `scripts/git_create_branches_helper.sh` and adjust in the following commands.
 
    ```bash
-   chmod 755 ./terraform-example-foundation/0-bootstrap/scripts/git_create_branches_helper.sh
-   ./terraform-example-foundation/0-bootstrap/scripts/git_create_branches_helper.sh
+   chmod 755 ./terraform-google-enterprise-genai/0-bootstrap/scripts/git_create_branches_helper.sh
+   ./terraform-google-enterprise-genai/0-bootstrap/scripts/git_create_branches_helper.sh
    ```
 
    You will see some GIT logs related to the branches creation in the console and the message  `"Branch creation and push completed for all repositories"` at the end of the script execution.
@@ -130,7 +130,7 @@ You must be authenticated to the VCS provider. See [GitHub authentication](https
 
    ```bash
    mkdir -p envs/shared
-   cp -RT ../terraform-example-foundation/0-bootstrap/ ./envs/shared
+   cp -RT ../terraform-google-enterprise-genai/0-bootstrap/ ./envs/shared
    cd ./envs/shared
    ```
 
@@ -187,7 +187,7 @@ export the OAuth Token ID as an environment variable:
 1. Use the helper script [validate-requirements.sh](../scripts/validate-requirements.sh) to validate your environment:
 
    ```bash
-   ../../../terraform-example-foundation/scripts/validate-requirements.sh  -o <ORGANIZATION_ID> -b <BILLING_ACCOUNT_ID> -u <END_USER_EMAIL> -e
+   ../../../terraform-google-enterprise-genai/scripts/validate-requirements.sh  -o <ORGANIZATION_ID> -b <BILLING_ACCOUNT_ID> -u <END_USER_EMAIL> -e
    ```
 
    **Note:** The script is not able to validate if the user is in a Cloud Identity or Google Workspace group with the required roles.
@@ -244,8 +244,8 @@ export the OAuth Token ID as an environment variable:
    ```bash
    mv backend.tf.cloud.example backend.tf
    cd ../../../
-   chmod 775 ./terraform-example-foundation/scripts/set-tfc-backend-and-remote.sh
-   ./terraform-example-foundation/scripts/set-tfc-backend-and-remote.sh
+   chmod 775 ./terraform-google-enterprise-genai/scripts/set-tfc-backend-and-remote.sh
+   ./terraform-google-enterprise-genai/scripts/set-tfc-backend-and-remote.sh
    cd ./gcp-bootstrap/envs/shared
    ```
 
@@ -293,7 +293,7 @@ we recommend that you request 50 additional projects for the **projects step ser
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/1-org/ .
+   cp -RT ../terraform-google-enterprise-genai/1-org/ .
    ```
 
 1. Rename `./envs/shared/terraform.example.tfvars` to `./envs/shared/terraform.tfvars`
@@ -379,7 +379,7 @@ See the shared folder [README.md](../1-org/envs/shared/README.md#inputs) for add
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/2-environments/ .
+   cp -RT ../terraform-google-enterprise-genai/2-environments/ .
    ```
 
 1. Rename `terraform.example.tfvars` to `terraform.tfvars`.
@@ -452,9 +452,9 @@ or go to [Deploying step 3-networks-hub-and-spoke](#deploying-step-3-networks-hu
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/3-networks-dual-svpc/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/3-networks-dual-svpc/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -609,9 +609,9 @@ An environment variable `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` will be set with th
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/3-networks-hub-and-spoke/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/3-networks-hub-and-spoke/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -755,9 +755,9 @@ An environment variable `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` will be set with th
 1. Copy contents of foundation to new repo.
 
    ```bash
-   cp -RT ../terraform-example-foundation/4-projects/ .
-   cp -RT ../terraform-example-foundation/policy-library/ ./policy-library
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/4-projects/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ ./policy-library
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 

--- a/0-bootstrap/README.md
+++ b/0-bootstrap/README.md
@@ -51,7 +51,7 @@ Hub and Spoke network model. It also sets up the global DNS hub.</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation)
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai)
 file.
 
 ## Purpose
@@ -119,7 +119,7 @@ See [troubleshooting](../docs/TROUBLESHOOTING.md) if you run into issues during 
 ## Deploying with Jenkins
 
 If you are using the `jenkins_bootstrap` sub-module, see
-[README-Jenkins](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/0-bootstrap/README-Jenkins.md)
+[README-Jenkins](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/0-bootstrap/README-Jenkins.md)
 for requirements and instructions on how to run the 0-bootstrap step. Using
 Jenkins requires a few manual steps, including configuring connectivity with
 your current Jenkins manager (controller) environment.
@@ -132,12 +132,12 @@ Using GitHub Actions requires manual creation of the GitHub repositories used in
 
 ## Deploying with Cloud Build
 
-1. Clone [terraform-example-foundation](https://github.com/terraform-google-modules/terraform-example-foundation) into your local environment and navigate to the `0-bootstrap` folder.
+1. Clone [terraform-google-enterprise-genai](https://github.com/terraform-google-modules/terraform-google-enterprise-genai) into your local environment and navigate to the `0-bootstrap` folder.
 
    ```bash
-   git clone https://github.com/terraform-google-modules/terraform-example-foundation.git
+   git clone https://github.com/terraform-google-modules/terraform-google-enterprise-genai.git
 
-   cd terraform-example-foundation/0-bootstrap
+   cd terraform-google-enterprise-genai/0-bootstrap
    ```
 
 1. Rename `terraform.example.tfvars` to `terraform.tfvars` and update the file with values from your environment:
@@ -223,7 +223,7 @@ Using GitHub Actions requires manual creation of the GitHub repositories used in
    ```
 
 1. (Optional) Run `terraform plan` to verify that state is configured correctly. You should see no changes from the previous state.
-1. Clone the policy repo and copy contents of policy-library to new repo. Clone the repo at the same level of the `terraform-example-foundation` folder.
+1. Clone the policy repo and copy contents of policy-library to new repo. Clone the repo at the same level of the `terraform-google-enterprise-genai` folder.
 
    ```bash
    cd ../..
@@ -232,7 +232,7 @@ Using GitHub Actions requires manual creation of the GitHub repositories used in
 
    cd gcp-policies
    git checkout -b main
-   cp -RT ../terraform-example-foundation/policy-library/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ .
    ```
 
 1. Commit changes and push your main branch to the policy repo.
@@ -258,9 +258,9 @@ Using GitHub Actions requires manual creation of the GitHub repositories used in
    git checkout -b plan
    mkdir -p envs/shared
 
-   cp -RT ../terraform-example-foundation/0-bootstrap/ ./envs/shared
-   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/0-bootstrap/ ./envs/shared
+   cp ../terraform-google-enterprise-genai/build/cloudbuild-tf-* .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
 
    git add .

--- a/1-org/README.md
+++ b/1-org/README.md
@@ -51,7 +51,7 @@ hub-and-spoke network model. It also sets up the global DNS hub.</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation).
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai).
 
 ## Purpose
 
@@ -113,11 +113,11 @@ This module creates and applies [tags](https://cloud.google.com/resource-manager
 ### Deploying with Cloud Build
 
 1. Clone the `gcp-org` repo based on the Terraform output from the `0-bootstrap` step.
-Clone the repo at the same level of the `terraform-example-foundation` folder.
+Clone the repo at the same level of the `terraform-google-enterprise-genai` folder.
 If required, run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get the Cloud Build Project ID.
 
    ```bash
-   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="terraform-example-foundation/0-bootstrap/" output -raw cloudbuild_project_id)
+   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="terraform-google-enterprise-genai/0-bootstrap/" output -raw cloudbuild_project_id)
    echo ${CLOUD_BUILD_PROJECT_ID}
 
    gcloud source repos clone gcp-org --project=${CLOUD_BUILD_PROJECT_ID}
@@ -134,9 +134,9 @@ If required, run `terraform output cloudbuild_project_id` in the `0-bootstrap` f
    cd gcp-org
    git checkout -b plan
 
-   cp -RT ../terraform-example-foundation/1-org/ .
-   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/1-org/ .
+   cp ../terraform-google-enterprise-genai/build/cloudbuild-tf-* .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -149,7 +149,7 @@ If required, run `terraform output cloudbuild_project_id` in the `0-bootstrap` f
 1. Check if a Security Command Center notification with the default name, **scc-notify**, already exists. If it exists, choose a different value for the `scc_notification_name` variable in the `./envs/shared/terraform.tfvars` file.
 
    ```bash
-   export ORGANIZATION_ID=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -json common_config | jq '.org_id' --raw-output)
+   export ORGANIZATION_ID=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -json common_config | jq '.org_id' --raw-output)
    gcloud scc notifications describe "scc-notify" --organization=${ORGANIZATION_ID}
    ```
 
@@ -163,7 +163,7 @@ If required, run `terraform output cloudbuild_project_id` in the `0-bootstrap` f
 1. Update the `envs/shared/terraform.tfvars` file with values from your environment and 0-bootstrap step. If the previous step showed a numeric value, un-comment the variable `create_access_context_manager_access_policy = false`. See the shared folder [README.md](./envs/shared/README.md) for additional information on the values in the `terraform.tfvars` file.
 
    ```bash
-   export backend_bucket=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw gcs_bucket_tfstate)
+   export backend_bucket=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw gcs_bucket_tfstate)
    echo "remote_state_bucket = ${backend_bucket}"
 
    sed -i "s/REMOTE_STATE_BUCKET/${backend_bucket}/" ./envs/shared/terraform.tfvars
@@ -200,7 +200,7 @@ If required, run `terraform output cloudbuild_project_id` in the `0-bootstrap` f
 If you received a `PERMISSION_DENIED` error while running the `gcloud access-context-manager` or the `gcloud scc notifications` commands, you can append the following to run the command as the Terraform service account:
 
 ```bash
---impersonate-service-account=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw organization_step_terraform_service_account_email)
+--impersonate-service-account=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw organization_step_terraform_service_account_email)
 ```
 
 ### Deploying with Jenkins
@@ -213,11 +213,11 @@ See `0-bootstrap` [README-GitHub.md](../0-bootstrap/README-GitHub.md#deploying-s
 
 ### Running Terraform locally
 
-1. The next instructions assume that you are at the same level of the `terraform-example-foundation` folder.
+1. The next instructions assume that you are at the same level of the `terraform-google-enterprise-genai` folder.
 Change into the `1-org` folder, copy the Terraform wrapper script, and ensure it can be executed.
 
    ```bash
-   cd terraform-example-foundation/1-org
+   cd terraform-google-enterprise-genai/1-org
    cp ../build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```

--- a/1-org/modules/cai-monitoring/README.md
+++ b/1-org/modules/cai-monitoring/README.md
@@ -5,7 +5,7 @@ Uses Google Cloud Asset Inventory to create a feed of IAM Policy change events, 
 
 ```hcl
 module "secure_cai_notification" {
-  source = "terraform-google-modules/terraform-example-foundation/google//1-org/modules/cai-monitoring"
+  source = "terraform-google-modules/terraform-google-enterprise-genai/google//1-org/modules/cai-monitoring"
 
   org_id               = <ORG ID>
   billing_account      = <BILLING ACCOUNT ID>

--- a/1-org/modules/centralized-logging/README.md
+++ b/1-org/modules/centralized-logging/README.md
@@ -10,7 +10,7 @@ The following example exports audit logs from two folders to the same storage de
 
 ```hcl
 module "logs_export" {
-  source = "terraform-google-modules/terraform-example-foundation/google//1-org/modules/centralized-logging"
+  source = "terraform-google-modules/terraform-google-enterprise-genai/google//1-org/modules/centralized-logging"
 
   resources = {
     fldr1 = "<folder1_id>"
@@ -35,7 +35,7 @@ The following example exports all logs from three projects - including the loggi
 
 ```hcl
 module "logging_logbucket" {
-  source = "terraform-google-modules/terraform-example-foundation/google//1-org/modules/centralized-logging"
+  source = "terraform-google-modules/terraform-google-enterprise-genai/google//1-org/modules/centralized-logging"
 
   resources = {
     prj1 = "<log_destination_project_id>"

--- a/2-environments/README.md
+++ b/2-environments/README.md
@@ -51,7 +51,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation).
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai).
 
 ## Purpose
 
@@ -90,11 +90,11 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 ### Deploying with Cloud Build
 
 1. Clone the `gcp-environments` repo based on the Terraform output from the `0-bootstrap` step.
-Clone the repo at the same level of the `terraform-example-foundation` folder, the following instructions assume this layout.
+Clone the repo at the same level of the `terraform-google-enterprise-genai` folder, the following instructions assume this layout.
 Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get the Cloud Build Project ID.
 
    ```bash
-   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="terraform-example-foundation/0-bootstrap/" output -raw cloudbuild_project_id)
+   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="terraform-google-enterprise-genai/0-bootstrap/" output -raw cloudbuild_project_id)
    echo ${CLOUD_BUILD_PROJECT_ID}
 
    gcloud source repos clone gcp-environments --project=${CLOUD_BUILD_PROJECT_ID}
@@ -108,9 +108,9 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    cd gcp-environments
    git checkout -b plan
 
-   cp -RT ../terraform-example-foundation/2-environments/ .
-   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/2-environments/ .
+   cp ../terraform-google-enterprise-genai/build/cloudbuild-tf-* .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -123,7 +123,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 1. Update the file with values from your environment and bootstrap (you can re-run `terraform output` in the 0-bootstrap directory to find these values). See any of the envs folder [README.md](./envs/production/README.md#inputs) files for additional information on the values in the `terraform.tfvars` file.
 
    ```bash
-   export backend_bucket=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw gcs_bucket_tfstate)
+   export backend_bucket=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw gcs_bucket_tfstate)
    echo "remote_state_bucket = ${backend_bucket}"
 
    sed -i "s/REMOTE_STATE_BUCKET/${backend_bucket}/" terraform.tfvars
@@ -212,10 +212,10 @@ See `0-bootstrap` [README-GitHub.md](../0-bootstrap/README-GitHub.md#deploying-s
 
 ### Run Terraform locally
 
-1. The next instructions assume that you are at the same level of the `terraform-example-foundation` folder. Change into `2-environments` folder, copy the Terraform wrapper script and ensure it can be executed.
+1. The next instructions assume that you are at the same level of the `terraform-google-enterprise-genai` folder. Change into `2-environments` folder, copy the Terraform wrapper script and ensure it can be executed.
 
    ```bash
-   cd terraform-example-foundation/2-environments
+   cd terraform-google-enterprise-genai/2-environments
    cp ../build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```

--- a/3-networks-dual-svpc/README.md
+++ b/3-networks-dual-svpc/README.md
@@ -51,7 +51,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation).
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai).
 
 ## Purpose
 
@@ -65,10 +65,10 @@ The purpose of this step is to:
 1. 0-bootstrap executed successfully.
 1. 1-org executed successfully.
 1. 2-environments executed successfully.
-1. Obtain the value for the access_context_manager_policy_id variable. It can be obtained by running the following commands. We assume you are at the same level as directory `terraform-example-foundation`, If you run them from another directory, adjust your paths accordingly.
+1. Obtain the value for the access_context_manager_policy_id variable. It can be obtained by running the following commands. We assume you are at the same level as directory `terraform-google-enterprise-genai`, If you run them from another directory, adjust your paths accordingly.
 
    ```bash
-   export ORGANIZATION_ID=$(terraform -chdir="terraform-example-foundation/0-bootstrap/" output -json common_config | jq '.org_id' --raw-output)
+   export ORGANIZATION_ID=$(terraform -chdir="terraform-google-enterprise-genai/0-bootstrap/" output -json common_config | jq '.org_id' --raw-output)
    export ACCESS_CONTEXT_MANAGER_ID=$(gcloud access-context-manager policies list --organization ${ORGANIZATION_ID} --format="value(name)")
    echo "access_context_manager_policy_id = ${ACCESS_CONTEXT_MANAGER_ID}"
    ```
@@ -142,11 +142,11 @@ If you are not able to use Dedicated or Partner Interconnect, you can also use a
 ### Deploying with Cloud Build
 
 1. Clone the `gcp-networks` repo based on the Terraform output from the `0-bootstrap` step.
-Clone the repo at the same level of the `terraform-example-foundation` folder, the following instructions assume this layout.
+Clone the repo at the same level of the `terraform-google-enterprise-genai` folder, the following instructions assume this layout.
 Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get the Cloud Build Project ID.
 
    ```bash
-   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="terraform-example-foundation/0-bootstrap/" output -raw cloudbuild_project_id)
+   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="terraform-google-enterprise-genai/0-bootstrap/" output -raw cloudbuild_project_id)
    echo ${CLOUD_BUILD_PROJECT_ID}
 
    gcloud source repos clone gcp-networks --project=${CLOUD_BUILD_PROJECT_ID}
@@ -158,9 +158,9 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    cd gcp-networks/
    git checkout -b plan
 
-   cp -RT ../terraform-example-foundation/3-networks-dual-svpc/ .
-   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/3-networks-dual-svpc/ .
+   cp ../terraform-google-enterprise-genai/build/cloudbuild-tf-* .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -178,13 +178,13 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    Use `terraform output` to get the backend bucket value from 0-bootstrap output.
 
    ```bash
-   export ORGANIZATION_ID=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -json common_config | jq '.org_id' --raw-output)
+   export ORGANIZATION_ID=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -json common_config | jq '.org_id' --raw-output)
    export ACCESS_CONTEXT_MANAGER_ID=$(gcloud access-context-manager policies list --organization ${ORGANIZATION_ID} --format="value(name)")
    echo "access_context_manager_policy_id = ${ACCESS_CONTEXT_MANAGER_ID}"
 
    sed -i "s/ACCESS_CONTEXT_MANAGER_ID/${ACCESS_CONTEXT_MANAGER_ID}/" ./access_context.auto.tfvars
 
-   export backend_bucket=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw gcs_bucket_tfstate)
+   export backend_bucket=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw gcs_bucket_tfstate)
    echo "remote_state_bucket = ${backend_bucket}"
 
    sed -i "s/REMOTE_STATE_BUCKET/${backend_bucket}/" ./common.auto.tfvars
@@ -203,10 +203,10 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 1. Use `terraform output` to get the Cloud Build project ID and the networks step Terraform Service Account from 0-bootstrap output. An environment variable `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` will be set using the Terraform Service Account to enable impersonation.
 
    ```bash
-   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw cloudbuild_project_id)
+   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw cloudbuild_project_id)
    echo ${CLOUD_BUILD_PROJECT_ID}
 
-   export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw networks_step_terraform_service_account_email)
+   export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw networks_step_terraform_service_account_email)
    echo ${GOOGLE_IMPERSONATE_SERVICE_ACCOUNT}
    ```
 
@@ -286,10 +286,10 @@ See `0-bootstrap` [README-GitHub.md](../0-bootstrap/README-GitHub.md#deploying-s
 
 ### Run Terraform locally
 
-1. The next instructions assume that you are at the same level of the `terraform-example-foundation` folder. Change into `3-networks-dual-svpc` folder, copy the Terraform wrapper script and ensure it can be executed.
+1. The next instructions assume that you are at the same level of the `terraform-google-enterprise-genai` folder. Change into `3-networks-dual-svpc` folder, copy the Terraform wrapper script and ensure it can be executed.
 
    ```bash
-   cd terraform-example-foundation/3-networks-dual-svpc
+   cd terraform-google-enterprise-genai/3-networks-dual-svpc
    cp ../build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```

--- a/4-projects/README.md
+++ b/4-projects/README.md
@@ -51,7 +51,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation).
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai).
 
 ## Purpose
 
@@ -59,8 +59,8 @@ The purpose of this step is to set up the folder structure, projects, and infras
 
 For each business unit, a shared `infra-pipeline` project is created along with Cloud Build triggers, CSRs for application infrastructure code and Google Cloud Storage buckets for state storage.
 
-This step follows the same [conventions](https://github.com/terraform-google-modules/terraform-example-foundation#branching-strategy) as the Foundation pipeline deployed in [0-bootstrap](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/0-bootstrap/README.md).
-A custom [workspace](https://github.com/terraform-google-modules/terraform-google-bootstrap/blob/master/modules/tf_cloudbuild_workspace/README.md) (`bu1-example-app`) is created by this pipeline and necessary roles are granted to the Terraform Service Account of this workspace by enabling variable `sa_roles` as shown in this [example](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/4-projects/modules/base_env/example_base_shared_vpc_project.tf).
+This step follows the same [conventions](https://github.com/terraform-google-modules/terraform-google-enterprise-genai#branching-strategy) as the Foundation pipeline deployed in [0-bootstrap](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/0-bootstrap/README.md).
+A custom [workspace](https://github.com/terraform-google-modules/terraform-google-bootstrap/blob/master/modules/tf_cloudbuild_workspace/README.md) (`bu1-example-app`) is created by this pipeline and necessary roles are granted to the Terraform Service Account of this workspace by enabling variable `sa_roles` as shown in this [example](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/4-projects/modules/base_env/example_base_shared_vpc_project.tf).
 
 This pipeline is utilized to deploy resources in projects across development/non-production/production in step [5-app-infra](../5-app-infra/README.md).
 Other Workspaces can also be created to isolate deployments if needed.
@@ -90,11 +90,11 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 ### Deploying with Cloud Build
 
 1. Clone the `gcp-projects` repo based on the Terraform output from the `0-bootstrap` step.
-Clone the repo at the same level of the `terraform-example-foundation` folder, the following instructions assume this layout.
+Clone the repo at the same level of the `terraform-google-enterprise-genai` folder, the following instructions assume this layout.
 Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get the Cloud Build Project ID.
 
    ```bash
-   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="terraform-example-foundation/0-bootstrap/" output -raw cloudbuild_project_id)
+   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="terraform-google-enterprise-genai/0-bootstrap/" output -raw cloudbuild_project_id)
    echo ${CLOUD_BUILD_PROJECT_ID}
 
    gcloud source repos clone gcp-projects --project=${CLOUD_BUILD_PROJECT_ID}
@@ -106,9 +106,9 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    cd gcp-projects
    git checkout -b plan
 
-   cp -RT ../terraform-example-foundation/4-projects/ .
-   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/4-projects/ .
+   cp ../terraform-google-enterprise-genai/build/cloudbuild-tf-* .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -128,7 +128,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 1. Use `terraform output` to get the backend bucket value from 0-bootstrap output.
 
    ```bash
-   export remote_state_bucket=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw gcs_bucket_tfstate)
+   export remote_state_bucket=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw gcs_bucket_tfstate)
    echo "remote_state_bucket = ${remote_state_bucket}"
 
    sed -i "s/REMOTE_STATE_BUCKET/${remote_state_bucket}/" ./common.auto.tfvars
@@ -146,10 +146,10 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 1. Use `terraform output` to get the Cloud Build project ID and the projects step Terraform Service Account from 0-bootstrap output. An environment variable `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` will be set using the Terraform Service Account to enable impersonation.
 
    ```bash
-   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw cloudbuild_project_id)
+   export CLOUD_BUILD_PROJECT_ID=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw cloudbuild_project_id)
    echo ${CLOUD_BUILD_PROJECT_ID}
 
-   export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw projects_step_terraform_service_account_email)
+   export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw projects_step_terraform_service_account_email)
    echo ${GOOGLE_IMPERSONATE_SERVICE_ACCOUNT}
    ```
 
@@ -235,10 +235,10 @@ See `0-bootstrap` [README-GitHub.md](../0-bootstrap/README-GitHub.md#deploying-s
 
 ### Run Terraform locally
 
-1. The next instructions assume that you are at the same level of the `terraform-example-foundation` folder. Change into `4-projects` folder, copy the Terraform wrapper script and ensure it can be executed.
+1. The next instructions assume that you are at the same level of the `terraform-google-enterprise-genai` folder. Change into `4-projects` folder, copy the Terraform wrapper script and ensure it can be executed.
 
    ```bash
-   cd terraform-example-foundation/4-projects
+   cd terraform-google-enterprise-genai/4-projects
    cp ../build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```

--- a/5-app-infra/0-gcp-policies/README.md
+++ b/5-app-infra/0-gcp-policies/README.md
@@ -50,7 +50,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation)
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai)
 file.
 
 ## Purpose
@@ -62,7 +62,7 @@ When using Cloud Build for deployment, Policy Verification must be checked.  Thi
 1. Ensure you are in a neutral directory outside any other git related repositories.
 
 1. Clone the `gcp-policies` repo based on the Terraform output from the `0-bootstrap` step.
-Clone the repo at the same level of the `terraform-example-foundation` folder, the following instructions assume this layout.
+Clone the repo at the same level of the `terraform-google-enterprise-genai` folder, the following instructions assume this layout.
 Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get the Cloud Build Project ID.
 
    ```bash

--- a/5-app-infra/1-artifact-publish/README.md
+++ b/5-app-infra/1-artifact-publish/README.md
@@ -50,7 +50,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation)
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai)
 file.
 
 ## Purpose
@@ -76,7 +76,7 @@ each folder under `images` has the full name and tag of the image that must be b
 Once pushed, the pipeline can be accessed by navigating to the project name created in step-4:
 
 ```bash
-terraform -chdir="../terraform-example-foundation/4-projects/business_unit_3/shared/" output -raw common_artifacts_project_id
+terraform -chdir="../terraform-google-enterprise-genai/4-projects/business_unit_3/shared/" output -raw common_artifacts_project_id
 ```
 
 ## Prerequisites
@@ -112,9 +112,9 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
    cd bu3-artifact-publish
    git checkout -b plan
 
-   cp -RT ../terraform-example-foundation/5-app-infra/1-artifact-publish/ .
-   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/5-app-infra/1-artifact-publish/ .
+   cp ../terraform-google-enterprise-genai/build/cloudbuild-tf-* .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -127,7 +127,7 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 1. Update the file with values from your environment and 0-bootstrap. See any of the business unit 1 envs folders [README.md](./business_unit_1/production/README.md) files for additional information on the values in the `common.auto.tfvars` file.
 
    ```bash
-   export remote_state_bucket=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
+   export remote_state_bucket=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
    echo "remote_state_bucket = ${remote_state_bucket}"
    sed -i "s/REMOTE_STATE_BUCKET/${remote_state_bucket}/" ./common.auto.tfvars
    ```
@@ -169,10 +169,10 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 
 ### Run Terraform locally
 
-1. The next instructions assume that you are at the same level of the `terraform-example-foundation` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
+1. The next instructions assume that you are at the same level of the `terraform-google-enterprise-genai` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
 
    ```bash
-   cd terraform-example-foundation/5-app-infra/projects/artifact-publish
+   cd terraform-google-enterprise-genai/5-app-infra/projects/artifact-publish
    cp ../../../build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```

--- a/5-app-infra/2-artifact-publish-repo/README.md
+++ b/5-app-infra/2-artifact-publish-repo/README.md
@@ -50,7 +50,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation)
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai)
 file.
 
 ## Usage

--- a/5-app-infra/3-service-catalog/README.md
+++ b/5-app-infra/3-service-catalog/README.md
@@ -50,7 +50,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation)
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai)
 file.
 
 ## Purpose(s)
@@ -111,7 +111,7 @@ The pipeline also listens for changes made to `plan`, `development`, `non-produc
 The pipeline can be accessed by navigating to the project name created in step-4:
 
 ```bash
-terraform -chdir="../terraform-example-foundation/4-projects/business_unit_3/shared/" output -raw service_catalog_project_id
+terraform -chdir="../terraform-google-enterprise-genai/4-projects/business_unit_3/shared/" output -raw service_catalog_project_id
 ```
 ## Prerequisites
 
@@ -146,9 +146,9 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
    cd bu3-service-catalog
    git checkout -b plan
 
-   cp -RT ../terraform-example-foundation/5-app-infra/3-service-catalog/ .
-   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/5-app-infra/3-service-catalog/ .
+   cp ../terraform-google-enterprise-genai/build/cloudbuild-tf-* .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -161,7 +161,7 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 1. Update the file with values from your environment and 0-bootstrap. See any of the business unit 1 envs folders [README.md](./business_unit_1/production/README.md) files for additional information on the values in the `common.auto.tfvars` file.
 
    ```bash
-   export remote_state_bucket=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
+   export remote_state_bucket=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
    echo "remote_state_bucket = ${remote_state_bucket}"
    sed -i "s/REMOTE_STATE_BUCKET/${remote_state_bucket}/" ./common.auto.tfvars
    ```
@@ -205,10 +205,10 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 
 ### Run Terraform locally
 
-1. The next instructions assume that you are at the same level of the `terraform-example-foundation` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
+1. The next instructions assume that you are at the same level of the `terraform-google-enterprise-genai` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
 
    ```bash
-   cd terraform-example-foundation/5-app-infra/projects/service-catalog
+   cd terraform-google-enterprise-genai/5-app-infra/projects/service-catalog
    cp ../../../build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```

--- a/5-app-infra/4-service-catalog-repo/README.md
+++ b/5-app-infra/4-service-catalog-repo/README.md
@@ -60,7 +60,7 @@ This repo provides a number of the [Google Service Catalog](https://cloud.google
 1. Enter the repo folder and copy over the service catalogs files from `5-app-infra/4-service-catalog-repo` folder.
    ```shell
    cd service-catalog
-   cp -RT ../terraform-example-foundation/5-app-infra/4-service-catalog-repo/ .
+   cp -RT ../terraform-google-enterprise-genai/5-app-infra/4-service-catalog-repo/ .
    ```
 
 1. Commit changes and push main branch to the new repo.

--- a/5-app-infra/5-vpc-sc/README.md
+++ b/5-app-infra/5-vpc-sc/README.md
@@ -50,7 +50,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation)
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai)
 file.
 
 ## VPC-SC

--- a/5-app-infra/6-machine-learning/README.md
+++ b/5-app-infra/6-machine-learning/README.md
@@ -50,7 +50,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation)
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai)
 file.
 
 ## Purpose
@@ -95,7 +95,7 @@ Step 12 in "Deploying with Cloud Build" highlights the necessary steps needed to
 ### Deploying with Cloud Build
 
 1. Clone the `gcp-policies` repo based on the Terraform output from the `0-bootstrap` step.
-Clone the repo at the same level of the `terraform-example-foundation` folder, the following instructions assume this layout.
+Clone the repo at the same level of the `terraform-google-enterprise-genai` folder, the following instructions assume this layout.
 Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get the Cloud Build Project ID.
 
    ```bash
@@ -115,7 +115,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    cd gcp-policies-app-infra
    git checkout -b main
 
-   cp -RT ../terraform-example-foundation/policy-library/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ .
    ```
 
 1. Commit changes and push your main branch to the new repo.
@@ -147,9 +147,9 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    cd bu3-machine-learning
    git checkout -b plan
 
-   cp -RT ../terraform-example-foundation/5-app-infra/6-machine-learning/ .
-   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/5-app-infra/6-machine-learning/ .
+   cp ../terraform-google-enterprise-genai/build/cloudbuild-tf-* .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -171,7 +171,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 1. Use `terraform output` to get the project backend bucket value from 0-bootstrap.
 
    ```bash
-   export remote_state_bucket=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
+   export remote_state_bucket=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
    echo "remote_state_bucket = ${remote_state_bucket}"
    sed -i "s/REMOTE_STATE_BUCKET/${remote_state_bucket}/" ./common.auto.tfvars
    ```
@@ -268,10 +268,10 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    ```
 ## Running Terraform locally
 
-1. The next instructions assume that you are at the same level of the `terraform-example-foundation` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
+1. The next instructions assume that you are at the same level of the `terraform-google-enterprise-genai` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
 
    ```bash
-   cd terraform-example-foundation/5-app-infra/projects/machine-learning
+   cd terraform-google-enterprise-genai/5-app-infra/projects/machine-learning
    cp ../../../build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```

--- a/5-app-infra/README.md
+++ b/5-app-infra/README.md
@@ -50,7 +50,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation)
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai)
 file.
 
 ## Purpose

--- a/5-app-infra/projects/artifact-publish/README.md
+++ b/5-app-infra/projects/artifact-publish/README.md
@@ -50,7 +50,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation)
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai)
 file.
 
 ## Purpose
@@ -76,7 +76,7 @@ each folder under `images` has the full name and tag of the image that must be b
 Once pushed, the pipeline can be accessed by navigating to the project name created in step-4:
 
 ```bash
-terraform -chdir="../terraform-example-foundation/4-projects/business_unit_3/shared/" output -raw common_artifacts_project_id
+terraform -chdir="../terraform-google-enterprise-genai/4-projects/business_unit_3/shared/" output -raw common_artifacts_project_id
 ```
 
 ## Prerequisites
@@ -99,7 +99,7 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 ### Deploying with Cloud Build
 
 1. Clone the `gcp-policies` repo based on the Terraform output from the `0-bootstrap` step.
-Clone the repo at the same level of the `terraform-example-foundation` folder, the following instructions assume this layout.
+Clone the repo at the same level of the `terraform-google-enterprise-genai` folder, the following instructions assume this layout.
 Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get the Cloud Build Project ID.
 
    ```bash
@@ -119,7 +119,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    cd gcp-policies-app-infra
    git checkout -b main
 
-   cp -RT ../terraform-example-foundation/policy-library/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ .
    ```
 
 1. Commit changes and push your main branch to the new repo.
@@ -151,9 +151,9 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    cd bu3-artifact-publish
    git checkout -b plan
 
-   cp -RT ../terraform-example-foundation/5-app-infra/projects/artifact-publish/ .
-   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/5-app-infra/projects/artifact-publish/ .
+   cp ../terraform-google-enterprise-genai/build/cloudbuild-tf-* .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -166,7 +166,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 1. Update the file with values from your environment and 0-bootstrap. See any of the business unit 1 envs folders [README.md](./business_unit_1/production/README.md) files for additional information on the values in the `common.auto.tfvars` file.
 
    ```bash
-   export remote_state_bucket=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
+   export remote_state_bucket=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
    echo "remote_state_bucket = ${remote_state_bucket}"
    sed -i "s/REMOTE_STATE_BUCKET/${remote_state_bucket}/" ./common.auto.tfvars
    ```
@@ -233,10 +233,10 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 
 ### Run Terraform locally
 
-1. The next instructions assume that you are at the same level of the `terraform-example-foundation` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
+1. The next instructions assume that you are at the same level of the `terraform-google-enterprise-genai` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
 
    ```bash
-   cd terraform-example-foundation/5-app-infra/projects/artifact-publish
+   cd terraform-google-enterprise-genai/5-app-infra/projects/artifact-publish
    cp ../../../build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```

--- a/5-app-infra/projects/machine-learning/README.md
+++ b/5-app-infra/projects/machine-learning/README.md
@@ -50,7 +50,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation)
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai)
 file.
 
 ## Purpose
@@ -96,7 +96,7 @@ Step 12 in "Deploying with Cloud Build" highlights the necessary steps needed to
 ### Deploying with Cloud Build
 
 1. Clone the `gcp-policies` repo based on the Terraform output from the `0-bootstrap` step.
-Clone the repo at the same level of the `terraform-example-foundation` folder, the following instructions assume this layout.
+Clone the repo at the same level of the `terraform-google-enterprise-genai` folder, the following instructions assume this layout.
 Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get the Cloud Build Project ID.
 
    ```bash
@@ -116,7 +116,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    cd gcp-policies-app-infra
    git checkout -b main
 
-   cp -RT ../terraform-example-foundation/policy-library/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ .
    ```
 
 1. Commit changes and push your main branch to the new repo.
@@ -148,9 +148,9 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    cd bu3-machine-learning
    git checkout -b plan
 
-   cp -RT ../terraform-example-foundation/5-app-infra/projects/machine-learning/ .
-   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/5-app-infra/projects/machine-learning/ .
+   cp ../terraform-google-enterprise-genai/build/cloudbuild-tf-* .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -165,7 +165,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 1. Use `terraform output` to get the project backend bucket value from 0-bootstrap.
 
    ```bash
-   export remote_state_bucket=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
+   export remote_state_bucket=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
    echo "remote_state_bucket = ${remote_state_bucket}"
    sed -i "s/REMOTE_STATE_BUCKET/${remote_state_bucket}/" ./common.auto.tfvars
    ```
@@ -315,10 +315,10 @@ we want the `unknown-project-number` here.  Add this into your `egress_policies`
 
 ## Running Terraform locally
 
-1. The next instructions assume that you are at the same level of the `terraform-example-foundation` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
+1. The next instructions assume that you are at the same level of the `terraform-google-enterprise-genai` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
 
    ```bash
-   cd terraform-example-foundation/5-app-infra/projects/machine-learning
+   cd terraform-google-enterprise-genai/5-app-infra/projects/machine-learning
    cp ../../../build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```

--- a/5-app-infra/projects/service-catalog/README.md
+++ b/5-app-infra/projects/service-catalog/README.md
@@ -50,7 +50,7 @@ Hub and Spoke network model. It also sets up the global DNS hub</td>
 </table>
 
 For an overview of the architecture and the parts, see the
-[terraform-example-foundation README](https://github.com/terraform-google-modules/terraform-example-foundation)
+[terraform-google-enterprise-genai README](https://github.com/terraform-google-modules/terraform-google-enterprise-genai)
 file.
 
 ## Purpose(s)
@@ -111,7 +111,7 @@ The pipeline also listens for changes made to `plan`, `development`, `non-produc
 The pipeline can be accessed by navigating to the project name created in step-4:
 
 ```bash
-terraform -chdir="../terraform-example-foundation/4-projects/business_unit_3/shared/" output -raw service_catalog_project_id
+terraform -chdir="../terraform-google-enterprise-genai/4-projects/business_unit_3/shared/" output -raw service_catalog_project_id
 ```
 ## Prerequisites
 
@@ -133,7 +133,7 @@ commands. The `-T` flag is needed for Linux, but causes problems for MacOS.
 ### Deploying with Cloud Build
 
 1. Clone the `gcp-policies` repo based on the Terraform output from the `0-bootstrap` step.
-Clone the repo at the same level of the `terraform-example-foundation` folder, the following instructions assume this layout.
+Clone the repo at the same level of the `terraform-google-enterprise-genai` folder, the following instructions assume this layout.
 Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get the Cloud Build Project ID.
 
    ```bash
@@ -153,7 +153,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    cd gcp-policies-app-infra
    git checkout -b main
 
-   cp -RT ../terraform-example-foundation/policy-library/ .
+   cp -RT ../terraform-google-enterprise-genai/policy-library/ .
    ```
 
 1. Commit changes and push your main branch to the new repo.
@@ -185,9 +185,9 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
    cd bu3-service-catalog
    git checkout -b plan
 
-   cp -RT ../terraform-example-foundation/5-app-infra/projects/service-catalog/ .
-   cp ../terraform-example-foundation/build/cloudbuild-tf-* .
-   cp ../terraform-example-foundation/build/tf-wrapper.sh .
+   cp -RT ../terraform-google-enterprise-genai/5-app-infra/projects/service-catalog/ .
+   cp ../terraform-google-enterprise-genai/build/cloudbuild-tf-* .
+   cp ../terraform-google-enterprise-genai/build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```
 
@@ -200,7 +200,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 1. Update the file with values from your environment and 0-bootstrap. See any of the business unit 1 envs folders [README.md](./business_unit_1/production/README.md) files for additional information on the values in the `common.auto.tfvars` file.
 
    ```bash
-   export remote_state_bucket=$(terraform -chdir="../terraform-example-foundation/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
+   export remote_state_bucket=$(terraform -chdir="../terraform-google-enterprise-genai/0-bootstrap/" output -raw projects_gcs_bucket_tfstate)
    echo "remote_state_bucket = ${remote_state_bucket}"
    sed -i "s/REMOTE_STATE_BUCKET/${remote_state_bucket}/" ./common.auto.tfvars
    ```
@@ -253,7 +253,7 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 1. Enter the repo folder and copy over the service catalogs files from `5-app-infra/source_repos` folder.
    ```shell
    cd service-catalog
-   cp -RT ../terraform-example-foundation/5-app-infra/source_repos/service-catalog/ .
+   cp -RT ../terraform-google-enterprise-genai/5-app-infra/source_repos/service-catalog/ .
    ```
 
 1. Commit changes and push main branch to the new repo.
@@ -268,10 +268,10 @@ Run `terraform output cloudbuild_project_id` in the `0-bootstrap` folder to get 
 
 ### Run Terraform locally
 
-1. The next instructions assume that you are at the same level of the `terraform-example-foundation` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
+1. The next instructions assume that you are at the same level of the `terraform-google-enterprise-genai` folder. Change into `5-app-infra` folder, copy the Terraform wrapper script and ensure it can be executed.
 
    ```bash
-   cd terraform-example-foundation/5-app-infra/projects/service-catalog
+   cd terraform-google-enterprise-genai/5-app-infra/projects/service-catalog
    cp ../../../build/tf-wrapper.sh .
    chmod 755 ./tf-wrapper.sh
    ```

--- a/ERRATA.md
+++ b/ERRATA.md
@@ -35,7 +35,7 @@ This will be addressed in the next version of the blueprint guide.
 - Cloud Asset Inventory will be integrated in a future release.
 - The unallocated IP address space in the Shared VPC networks, described in Section 7.3, is currently being used by Private Service Networking in this release.
 
-## [1.x](https://github.com/terraform-google-modules/terraform-example-foundation/releases/tag/v1.0.0)
+## [1.x](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/releases/tag/v1.0.0)
 ### Code Discrepancies
 
 #### Labeling

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-This repository serves as a example for configuring an environment for the development and deployment of Machine Learning applications using the Vertex AI platform on Google Cloud. It seamlessly integrates the Cloud Foundation Toolkit (CFT) and implements robust security measures, drawing heavily from the [terraform-example-foundation](https://github.com/terraform-google-modules/terraform-example-foundation/tree/v4.0.0) codebase.
+This repository serves as a example for configuring an environment for the development and deployment of Machine Learning applications using the Vertex AI platform on Google Cloud. It seamlessly integrates the Cloud Foundation Toolkit (CFT) and implements robust security measures, drawing heavily from the [terraform-google-enterprise-genai](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/tree/v4.0.0) codebase.
 
-The repo is separated in distinct Terraform projects, each within their own directory that must be applied separately, but in sequence, for more information about each step, please refer to [terraform-example-foundation](https://github.com/terraform-google-modules/terraform-example-foundation/tree/v4.0.0). Comparing to the foundation repository, the key differences from the steps in foundation to steps in these repository are:
+The repo is separated in distinct Terraform projects, each within their own directory that must be applied separately, but in sequence, for more information about each step, please refer to [terraform-google-enterprise-genai](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/tree/v4.0.0). Comparing to the foundation repository, the key differences from the steps in foundation to steps in these repository are:
 
 * [1. org](./1-org/)
     * Specific to this repository, it will also configure Machine Learning Organization Policies.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,7 +13,7 @@ If you see other quota errors, see the [Quota documentation](https://cloud.googl
 
 ## What is a "named" branch?
 
-Certain branches in the terraform-example-foundation are considered to be
+Certain branches in the terraform-google-enterprise-genai are considered to be
 _named branches_. Pushing to a named branch causes the _apply_ command to be
 run. Pushing to branches other than the named branches does not run _apply_.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -191,7 +191,7 @@ At this time the alternatives are:
 1. To use a [workaround](https://stackoverflow.com/a/62827358) to force Google API calls in Cloud Shell to use an IP from the `private.googleapis.com` range (199.36.153.8/30 ) or
 1. To deploy the foundation code from a local machine that supports IPv6.
 
-If you use the workaround, the API list should include the ones that are [allowed](../policy-library/policies/constraints/serviceusage_allow_basic_apis.yaml) in the terraform-example-foundation policy library.
+If you use the workaround, the API list should include the ones that are [allowed](../policy-library/policies/constraints/serviceusage_allow_basic_apis.yaml) in the terraform-google-enterprise-genai policy library.
 
 ### Error: Unsupported attribute
 
@@ -473,4 +473,4 @@ You can get this information from step `0-bootstrap` by running the following co
 
 **Terraform State lock possible causes:**
 
-- If you realize that the Terraform State lock was due to a build timeout increase the build timeout on [build configuration](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/build/cloudbuild-tf-apply.yaml#L15).
+- If you realize that the Terraform State lock was due to a build timeout increase the build timeout on [build configuration](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/build/cloudbuild-tf-apply.yaml#L15).

--- a/docs/upgrading_to_v2.0.md
+++ b/docs/upgrading_to_v2.0.md
@@ -2,7 +2,7 @@
 
 Before moving forward with adopting components of V2, please review the list of
 breaking changes below. You can find a list of all changes in the
-[Changelog](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/CHANGELOG.md).
+[Changelog](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/CHANGELOG.md).
 
 **Note:** There is no in-place upgrade path from v1 to v2.
 

--- a/docs/upgrading_to_v3.0.md
+++ b/docs/upgrading_to_v3.0.md
@@ -1,5 +1,5 @@
 # Upgrade Guidance
-Before moving forward with adopting components of v3, review the list of breaking changes below. You can find a complete list of features, bug fixes and other updates in the [Changelog](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/CHANGELOG.md).
+Before moving forward with adopting components of v3, review the list of breaking changes below. You can find a complete list of features, bug fixes and other updates in the [Changelog](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/CHANGELOG.md).
 
 **Important:** There is no in-place upgrade path from v2 to v3.
 
@@ -17,7 +17,7 @@ There is no direct path for upgrading from v2 to v3 as this may result in resour
 
 In case you require to integrate some of the v3's features, we recommend to review the documentation regarding the feature you are interested in and use v3's code as a guidance for its implementation. We also recommend to review the output from `terraform plan` for any destructive operations before applying the updates.
 
-**Note:** You must verify that you are using the correct version for `terraform` and `gcloud`. You can check these and other additional requirements using this [validate script](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/scripts/validate-requirements.sh).
+**Note:** You must verify that you are using the correct version for `terraform` and `gcloud`. You can check these and other additional requirements using this [validate script](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/scripts/validate-requirements.sh).
 
 ### Move Blocks
 

--- a/helpers/foundation-deployer/README.md
+++ b/helpers/foundation-deployer/README.md
@@ -29,11 +29,11 @@ Helper tool to deploy the Terraform example foundation.
 ### Prepare the deploy environment
 
 - Create a directory in the file system to host the Cloud Source repositories the will be created and a copy of the terraform example foundation.
-- Clone the `terraform-example-foundation` repository on this directory.
+- Clone the `terraform-google-enterprise-genai` repository on this directory.
 
     ```text
     deploy-directory/
-    └── terraform-example-foundation
+    └── terraform-google-enterprise-genai
     ```
 
 - Copy the file [global.tfvars.example](./global.tfvars.example) as `global.tfvars` to the same directory.
@@ -41,21 +41,21 @@ Helper tool to deploy the Terraform example foundation.
     ```text
     deploy-directory/
     └── global.tfvars
-    └── terraform-example-foundation
+    └── terraform-google-enterprise-genai
     ```
 
 - Update `global.tfvars` with values from your environment.
-- The `0-bootstrap` README [prerequisites](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/0-bootstrap/README.md#prerequisites)  section has additional prerequisites needed to run this helper.
+- The `0-bootstrap` README [prerequisites](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/0-bootstrap/README.md#prerequisites)  section has additional prerequisites needed to run this helper.
 - Variable `code_checkout_path` is the full path to `deploy-directory` directory.
-- Variable `foundation_code_path` is the full path to `terraform-example-foundation` directory.
+- Variable `foundation_code_path` is the full path to `terraform-google-enterprise-genai` directory.
 - See the READMEs for the stages for additional information:
-  - [0-bootstrap](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/0-bootstrap/README.md)
-  - [1-org](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/1-org/README.md)
-  - [2-environments](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/2-environments/README.md)
-  - [3-networks-dual-svpc](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/3-networks-dual-svpc)
-  - [3-networks-hub-and-spoke](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/3-networks-hub-and-spoke)
-  - [4-projects](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/4-projects)
-  - [5-app-infra](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/5-app-infra)
+  - [0-bootstrap](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/0-bootstrap/README.md)
+  - [1-org](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/1-org/README.md)
+  - [2-environments](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/2-environments/README.md)
+  - [3-networks-dual-svpc](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/3-networks-dual-svpc)
+  - [3-networks-hub-and-spoke](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/3-networks-hub-and-spoke)
+  - [4-projects](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/4-projects)
+  - [5-app-infra](https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/5-app-infra)
 
 ### Location
 
@@ -132,7 +132,7 @@ Im addition to the variables declared in the file `global.tfvars` for configurin
     └── gcp-policies-app-infra
     └── gcp-projects
     └── global.tfvars
-    └── terraform-example-foundation
+    └── terraform-google-enterprise-genai
     ```
 
 ### Supported flags

--- a/helpers/foundation-deployer/gcp/gcp.go
+++ b/helpers/foundation-deployer/gcp/gcp.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/tidwall/gjson"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration/testutils"
 )
 
 const (

--- a/helpers/foundation-deployer/global.tfvars.example
+++ b/helpers/foundation-deployer/global.tfvars.example
@@ -29,7 +29,7 @@ validator_project_id = "EXISTING_PROJECT_ID"
 
 
 // 0-bootstrap inputs
-// https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/0-bootstrap/README.md#inputs
+// https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/0-bootstrap/README.md#inputs
 
 org_id          = "REPLACE_ME" # format "000000000000"
 billing_account = "REPLACE_ME" # format "000000-000000-000000"
@@ -55,7 +55,7 @@ folder_prefix  = "fldr"
 
 // Optional - for enabling the automatic groups creation, uncomment the groups
 // variable and update the values with the desired group names
-// https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/0-bootstrap/README.md#optional---automatic-creation-of-google-cloud-identity-groups
+// https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/0-bootstrap/README.md#optional---automatic-creation-of-google-cloud-identity-groups
 
 // After deploy, the Bootstrap service account will need to be granted "Group Admin" role in the
 // Google Workspace by a Super Admin before Cloud Build builds can be executed by the Bootstrap workspace.
@@ -85,7 +85,7 @@ folder_prefix  = "fldr"
 
 
 // 1-org inputs
-// https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/1-org/envs/shared/README.md#inputs
+// https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/1-org/envs/shared/README.md#inputs
 
 audit_data_users   = "REPLACE_ME" # "gcp-security-admins@example.com"
 billing_data_users = "REPLACE_ME" # "gcp-billing-data-users@example.com"
@@ -101,8 +101,8 @@ log_export_storage_location                 = "US"
 billing_export_dataset_location             = "US"
 
 // Choose witch network architecture to use:
-// Dual Shared VPC: https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/3-networks-dual-svpc/README.md
-// Hub And Spoke: https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/3-networks-hub-and-spoke/README.md
+// Dual Shared VPC: https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/3-networks-dual-svpc/README.md
+// Hub And Spoke: https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/3-networks-hub-and-spoke/README.md
 
 enable_hub_and_spoke = false
 
@@ -115,14 +115,14 @@ create_unique_tag_key = false
 
 
 // 2-environments inputs
-// https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/2-environments/envs/production/README.md#inputs
+// https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/2-environments/envs/production/README.md#inputs
 
 monitoring_workspace_users = "REPLACE_ME" # "gcp-monitoring-admins@example.com"
 
 
 // 3-networks inputs
-// https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/3-networks-hub-and-spoke/envs/production/README.md#inputs
-// https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/3-networks-hub-and-spoke/envs/shared/README.md#inputs
+// https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/3-networks-hub-and-spoke/envs/production/README.md#inputs
+// https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/3-networks-hub-and-spoke/envs/shared/README.md#inputs
 
 domain = "example.com." # The DNS name of peering managed zone. Must end with a period.
 
@@ -149,7 +149,7 @@ target_name_server_addresses = [
 
 
 // 4-projects inputs
-// https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/4-projects/business_unit_1/production/README.md#inputs
+// https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/4-projects/business_unit_1/production/README.md#inputs
 
 projects_gcs_location = "US"
 projects_kms_location = "us"

--- a/helpers/foundation-deployer/go.mod
+++ b/helpers/foundation-deployer/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer
+module github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer
 
 go 1.20
 
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.16.1
 	github.com/mitchellh/go-testing-interface v1.14.2-0.20210821155943-2d9075ca8770
 	github.com/stretchr/testify v1.8.2
-	github.com/terraform-google-modules/terraform-example-foundation/test/integration v0.0.0-20230503230051-e9e2618ef515
+	github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration v0.0.0-20230503230051-e9e2618ef515
 	github.com/tidwall/gjson v1.14.4
 )
 

--- a/helpers/foundation-deployer/go.sum
+++ b/helpers/foundation-deployer/go.sum
@@ -447,8 +447,8 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/terraform-google-modules/terraform-example-foundation/test/integration v0.0.0-20230503230051-e9e2618ef515 h1:9WpwfiGRUEX5e3qeC93M/TWxmVeSD8vz1B8c5FumdAE=
-github.com/terraform-google-modules/terraform-example-foundation/test/integration v0.0.0-20230503230051-e9e2618ef515/go.mod h1:4EkFeYb9/Cjbqc4uynVvcmV8MCK7VK5dGuR2yD4r8EU=
+github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration v0.0.0-20230503230051-e9e2618ef515 h1:9WpwfiGRUEX5e3qeC93M/TWxmVeSD8vz1B8c5FumdAE=
+github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration v0.0.0-20230503230051-e9e2618ef515/go.mod h1:4EkFeYb9/Cjbqc4uynVvcmV8MCK7VK5dGuR2yD4r8EU=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
 github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/helpers/foundation-deployer/main.go
+++ b/helpers/foundation-deployer/main.go
@@ -25,11 +25,11 @@ import (
 
 	"github.com/mitchellh/go-testing-interface"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/gcp"
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/msg"
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/stages"
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/steps"
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/utils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/gcp"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/msg"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/stages"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/steps"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/utils"
 )
 
 var (

--- a/helpers/foundation-deployer/msg/msg.go
+++ b/helpers/foundation-deployer/msg/msg.go
@@ -23,11 +23,11 @@ import (
 
 const (
 	size            = 70
-	readmeURL       = "https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/%s/README.md"
+	readmeURL       = "https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/%s/README.md"
 	cloudBuildURL   = "https://console.cloud.google.com/cloud-build/builds;region=%s?project=%s"
 	buildErrorURL   = "https://console.cloud.google.com/cloud-build/builds;region=%s/%s?project=%s"
 	quotaURL        = "https://support.google.com/code/contact/billing_quota_increase"
-	troubleQuotaURL = "https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/docs/TROUBLESHOOTING.md#billing-quota-exceeded"
+	troubleQuotaURL = "https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/docs/TROUBLESHOOTING.md#billing-quota-exceeded"
 	groupAdminURL   = "https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account"
 )
 

--- a/helpers/foundation-deployer/stages/apply.go
+++ b/helpers/foundation-deployer/stages/apply.go
@@ -22,12 +22,12 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/mitchellh/go-testing-interface"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/gcp"
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/msg"
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/steps"
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/utils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/gcp"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/msg"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/steps"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/utils"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration/testutils"
 )
 
 func DeployBootstrapStage(t testing.TB, s steps.Steps, tfvars GlobalTFVars, c CommonConf) error {

--- a/helpers/foundation-deployer/stages/data.go
+++ b/helpers/foundation-deployer/stages/data.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/mitchellh/go-testing-interface"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/utils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/utils"
 )
 
 const (

--- a/helpers/foundation-deployer/stages/destroy.go
+++ b/helpers/foundation-deployer/stages/destroy.go
@@ -23,9 +23,9 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/mitchellh/go-testing-interface"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/steps"
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/utils"
-	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/steps"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/utils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration/testutils"
 )
 
 const (
@@ -194,9 +194,9 @@ func destroyStage(t testing.TB, sc StageConf, s steps.Steps, c CommonConf) error
 	for _, g := range groupingUnits {
 		err := s.RunDestroyStep(fmt.Sprintf("%s.%s.apply-shared", sc.Repo, g), func() error {
 			options := &terraform.Options{
-				TerraformDir: filepath.Join(gcpPath, g, "shared"),
-				Logger:       c.Logger,
-				NoColor:      true,
+				TerraformDir:             filepath.Join(gcpPath, g, "shared"),
+				Logger:                   c.Logger,
+				NoColor:                  true,
 				RetryableTerraformErrors: testutils.RetryableTransientErrors,
 				MaxRetries:               2,
 				TimeBetweenRetries:       2 * time.Minute,

--- a/helpers/foundation-deployer/stages/validate.go
+++ b/helpers/foundation-deployer/stages/validate.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/mitchellh/go-testing-interface"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/helpers/foundation-deployer/gcp"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/helpers/foundation-deployer/gcp"
 )
 
 const (

--- a/scripts/set-tfc-backend-and-remote.sh
+++ b/scripts/set-tfc-backend-and-remote.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Define the root folder where you want to start the search and renaming
-root_folder="./terraform-example-foundation"
+root_folder="./terraform-google-enterprise-genai"
 
 # Use 'find' to locate all files named 'backend.tf'
 # in the specified folder and its subfolders, excluding directories that start with ".terraform"

--- a/scripts/validate-requirements.sh
+++ b/scripts/validate-requirements.sh
@@ -21,7 +21,7 @@
 # Expected versions of the installers
 TF_VERSION="1.3.0"
 # Version 393.0.0 due to terraform-tools 0.5.0 version that fixes the issue
-# mentioned in this PR https://github.com/terraform-google-modules/terraform-example-foundation/pull/729#discussion_r919427668
+# mentioned in this PR https://github.com/terraform-google-modules/terraform-google-enterprise-genai/pull/729#discussion_r919427668
 GCLOUD_SDK_VERSION="393.0.0"
 GIT_VERSION="2.28.0"
 
@@ -126,7 +126,7 @@ function validate_git(){
 
     if ! git config init.defaultBranch | grep "main" >/dev/null ; then
         echo "  git default branch must be configured as main."
-        echo "  See the instructions at https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/docs/TROUBLESHOOTING.md#default-branch-setting ."
+        echo "  See the instructions at https://github.com/terraform-google-modules/terraform-google-enterprise-genai/blob/master/docs/TROUBLESHOOTING.md#default-branch-setting ."
         ERRORS+=$'  git default branch must be configured as main.\n'
     fi
 }

--- a/test/integration/bootstrap/bootstrap_test.go
+++ b/test/integration/bootstrap/bootstrap_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration/testutils"
 )
 
 // fileExists check if a give file exists
@@ -47,7 +47,7 @@ func fileExists(filePath string) (bool, error) {
 func TestBootstrap(t *testing.T) {
 
 	vars := map[string]interface{}{
-		"bucket_force_destroy": true,
+		"bucket_force_destroy":             true,
 		"bucket_tfstate_kms_force_destroy": true,
 	}
 

--- a/test/integration/envs/envs_test.go
+++ b/test/integration/envs/envs_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/utils"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration/testutils"
 )
 
 func TestEnvs(t *testing.T) {

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-google-modules/terraform-example-foundation/test/integration
+module github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration
 
 go 1.20
 

--- a/test/integration/networks/networks_test.go
+++ b/test/integration/networks/networks_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration/testutils"
 )
 
 func getNetworkMode(t *testing.T) string {

--- a/test/integration/org/org_test.go
+++ b/test/integration/org/org_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration/testutils"
 )
 
 func TestOrg(t *testing.T) {

--- a/test/integration/projects-shared/projects_shared_test.go
+++ b/test/integration/projects-shared/projects_shared_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration/testutils"
 )
 
 func TestProjectsShared(t *testing.T) {

--- a/test/integration/projects/projects_test.go
+++ b/test/integration/projects/projects_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration/testutils"
 )
 
 func getNetworkMode(t *testing.T) string {

--- a/test/integration/shared/shared_test.go
+++ b/test/integration/shared/shared_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terraform-google-modules/terraform-example-foundation/test/integration/testutils"
+	"github.com/terraform-google-modules/terraform-google-enterprise-genai/test/integration/testutils"
 )
 
 func isHubAndSpokeMode(t *testing.T) bool {


### PR DESCRIPTION
This pull request update all fields using `terraform-example-foundation` to `terraform-google-enterprise-genai`. 