### PR TITLE
fix: refactoring to fit cloud build service account changes

### DIFF
--- a/5-app-infra/README.md
+++ b/5-app-infra/README.md
@@ -619,6 +619,14 @@ unset GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
    gcloud iam service-accounts add-iam-policy-binding ${terraform_sa} --project ${project_id} --member="${member}" --role="roles/iam.serviceAccountTokenCreator"
    ```
 
+1. Update the `log_bucket` variable with the value of the `logs_export_storage_bucket_name`.
+
+  ```bash
+   export log_bucket=$(terraform -chdir="../gcp-org/envs/shared" output -raw logs_export_storage_bucket_name)
+   echo "log_bucket = ${log_bucket}"
+   sed -i "s/REPLACE_LOG_BUCKET/${log_bucket}/" ./common.auto.tfvars
+   ```
+
 1. Update `backend.tf` with your bucket from the infra pipeline output.
 
    ```bash

--- a/5-app-infra/modules/publish_artifacts/data.tf
+++ b/5-app-infra/modules/publish_artifacts/data.tf
@@ -17,3 +17,10 @@
 data "google_project" "project" {
   project_id = var.project_id
 }
+
+data "google_sourcerepo_repository" "artifacts_repo" {
+  name    = var.name
+  project = var.project_id
+}
+
+data "google_client_openid_userinfo" "current_user" {}

--- a/5-app-infra/modules/publish_artifacts/locals.tf
+++ b/5-app-infra/modules/publish_artifacts/locals.tf
@@ -15,8 +15,11 @@
  */
 
 locals {
-  env_code = substr(var.environment, 0, 1)
-  name_var = format("%s-%s", local.env_code, var.name)
+  current_user_email  = data.google_client_openid_userinfo.current_user.email
+  current_user_domain = split("@", local.current_user_email)[1]
+  current_member      = strcontains(local.current_user_domain, "iam.gserviceaccount.com") ? "serviceAccount:${local.current_user_email}" : "user:${local.current_user_email}"
+  env_code            = substr(var.environment, 0, 1)
+  name_var            = format("%s-%s", local.env_code, var.name)
   # key_ring_var = "projects/${var.cmek_project_id}/locations/${var.region}/keyRings/sample-keyring"
   region_short_code = {
     "us-central1" = "usc1"

--- a/5-app-infra/modules/publish_artifacts/main.tf
+++ b/5-app-infra/modules/publish_artifacts/main.tf
@@ -74,34 +74,85 @@ resource "google_artifact_registry_repository" "repo" {
   }
   depends_on = [
     google_kms_crypto_key_iam_member.artifact-kms-key-binding,
-
   ]
 }
+
 resource "google_artifact_registry_repository_iam_member" "project" {
   for_each   = toset(local.trigger_sa_roles)
   project    = var.project_id
   repository = google_artifact_registry_repository.repo.repository_id
   location   = var.region
   role       = each.key
-  # member     = "serviceAccount:${google_service_account.trigger_sa.email}"
-  member = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member     = google_service_account.trigger_sa.member
 }
 
-# resource "google_sourcerepo_repository" "artifact_repo" {
-#   project = var.project_id
-#   name    = var.name
-# }
+resource "google_service_account" "trigger_sa" {
+  account_id   = var.docker_build_sa_id
+  display_name = "Docker Build Service Account"
+  project      = var.project_id
+}
+
+resource "google_service_account_iam_member" "impersonate" {
+  service_account_id = google_service_account.trigger_sa.id
+  role               = "roles/iam.serviceAccountUser"
+  member             = local.current_member
+}
+
+resource "random_string" "suffix" {
+  length  = 10
+  special = false
+  upper   = false
+}
+
+// Add Service Agent for Storage
+resource "google_kms_crypto_key_iam_member" "storage_agent" {
+  crypto_key_id = var.kms_crypto_key
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
+  #member = "serviceAccount:${google_project_service_identity.storage.email}"
+}
+
+resource "google_storage_bucket" "cloud_build_logs" {
+  name                        = "artifacts-pipeline-logs-${random_string.suffix.result}"
+  storage_class               = "REGIONAL"
+  project                     = var.project_id
+  location                    = var.region
+  uniform_bucket_level_access = true
+
+  encryption {
+    default_kms_key_name = var.kms_crypto_key
+  }
+
+  depends_on = [google_kms_crypto_key_iam_member.storage_agent]
+}
+
+resource "google_sourcerepo_repository_iam_member" "repo_reader" {
+  repository = data.google_sourcerepo_repository.artifacts_repo.id
+  role       = "roles/source.reader"
+  member     = google_service_account.trigger_sa.member
+}
+
+resource "google_storage_bucket_iam_member" "storage_admin" {
+  bucket = google_storage_bucket.cloud_build_logs.name
+  role   = "roles/storage.admin"
+  member = google_service_account.trigger_sa.member
+}
+
 resource "google_cloudbuild_trigger" "docker_build" {
-  name     = "docker-build"
-  project  = var.project_id
-  location = var.region
+  name            = "docker-build"
+  project         = var.project_id
+  location        = var.region
+  service_account = google_service_account.trigger_sa.id
 
   trigger_template {
-    branch_name = "^main$"
-    repo_name   = var.name
+    branch_name  = "^main$"
+    repo_name    = var.name
+    invert_regex = false
   }
+
   build {
-    timeout = "1800s"
+    logs_bucket = google_storage_bucket.cloud_build_logs.name
+    timeout     = "1800s"
     step {
       id         = "unshallow"
       name       = "gcr.io/cloud-builders/git"
@@ -159,4 +210,6 @@ resource "google_cloudbuild_trigger" "docker_build" {
       ]
     }
   }
+
+  depends_on = [google_service_account_iam_member.impersonate]
 }

--- a/5-app-infra/modules/publish_artifacts/variables.tf
+++ b/5-app-infra/modules/publish_artifacts/variables.tf
@@ -74,3 +74,9 @@ variable "kms_crypto_key" {
   description = "KMS Key to be used"
   type        = string
 }
+
+variable "docker_build_sa_id" {
+  description = "Account Id of Docker Build Pipeline SA"
+  type        = string
+  default     = "docker-build"
+}

--- a/5-app-infra/modules/service_catalog/data.tf
+++ b/5-app-infra/modules/service_catalog/data.tf
@@ -17,3 +17,10 @@
 data "google_project" "project" {
   project_id = var.project_id
 }
+
+data "google_sourcerepo_repository" "artifacts_repo" {
+  name    = var.name
+  project = var.project_id
+}
+
+data "google_client_openid_userinfo" "current_user" {}

--- a/5-app-infra/modules/service_catalog/locals.tf
+++ b/5-app-infra/modules/service_catalog/locals.tf
@@ -15,12 +15,14 @@
  */
 
 locals {
-  # github_repository = replace(var.github_remote_uri, "https://", "")
-  log_bucket_prefix = "bkt"
+  current_user_email  = data.google_client_openid_userinfo.current_user.email
+  current_user_domain = split("@", local.current_user_email)[1]
+  current_member      = strcontains(local.current_user_domain, "iam.gserviceaccount.com") ? "serviceAccount:${local.current_user_email}" : "user:${local.current_user_email}"
+  log_bucket_prefix   = "bkt"
   bucket_permissions = {
 
     "roles/storage.admin" = [
-      "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+      google_service_account.trigger_sa.member,
     ],
     "roles/storage.legacyObjectReader" = [
       "serviceAccount:${var.machine_learning_project_number}@cloudbuild.gserviceaccount.com",

--- a/5-app-infra/modules/service_catalog/variables.tf
+++ b/5-app-infra/modules/service_catalog/variables.tf
@@ -52,3 +52,9 @@ variable "log_bucket" {
   description = "Bucket to store logs from service catalog bucket"
   type        = string
 }
+
+variable "trigger_sa_id" {
+  description = "Account Id of Docker Build Pipeline SA"
+  type        = string
+  default     = "svc-catalog"
+}

--- a/5-app-infra/projects/service-catalog/business_unit_3/shared/README.md
+++ b/5-app-infra/projects/service-catalog/business_unit_3/shared/README.md
@@ -4,6 +4,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | instance\_region | The region where compute instance will be created. A subnetwork must exists in the instance region. | `string` | n/a | yes |
+| log\_bucket | Log bucket to be used by Service Catalog Bucket | `string` | n/a | yes |
 | remote\_state\_bucket | Backend bucket to load remote state information from previous steps. | `string` | n/a | yes |
 
 ## Outputs

--- a/5-app-infra/projects/service-catalog/business_unit_3/shared/common.auto.tfvars
+++ b/5-app-infra/projects/service-catalog/business_unit_3/shared/common.auto.tfvars
@@ -1,0 +1,1 @@
+../../common.auto.tfvars

--- a/5-app-infra/projects/service-catalog/business_unit_3/shared/variables.tf
+++ b/5-app-infra/projects/service-catalog/business_unit_3/shared/variables.tf
@@ -23,3 +23,8 @@ variable "remote_state_bucket" {
   description = "Backend bucket to load remote state information from previous steps."
   type        = string
 }
+
+variable "log_bucket" {
+  description = "Log bucket to be used by Service Catalog Bucket"
+  type        = string
+}

--- a/5-app-infra/projects/service-catalog/common.auto.example.tfvars
+++ b/5-app-infra/projects/service-catalog/common.auto.example.tfvars
@@ -18,6 +18,8 @@ instance_region = "us-central1" // should be one of the regions used to create n
 
 remote_state_bucket = "REMOTE_STATE_BUCKET"
 
+log_bucket = "REPLACE_LOG_BUCKET"
+
 # github_ api_ token = "PUT IN TOKEN"
 
 # github_app_installation_id = "18685983"

--- a/docs/assets/terraform/4-projects/ml_business_unit/shared/README.md
+++ b/docs/assets/terraform/4-projects/ml_business_unit/shared/README.md
@@ -34,6 +34,7 @@
 | service\_catalog\_project\_id | Service Catalog Project ID. |
 | service\_catalog\_repo\_id | ID of the Service Catalog repository |
 | service\_catalog\_repo\_name | The name of the Service Catalog repository |
+| shared\_level\_keyrings | Keyrings used on shared level project creation |
 | state\_buckets | GCS Buckets to store TF state |
 | terraform\_service\_accounts | APP Infra Pipeline Terraform Accounts. |
 

--- a/docs/assets/terraform/5-appinfra/service-catalog-infra-repo/ml_business_unit/shared/README.md
+++ b/docs/assets/terraform/5-appinfra/service-catalog-infra-repo/ml_business_unit/shared/README.md
@@ -4,6 +4,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | instance\_region | The region where compute instance will be created. A subnetwork must exists in the instance region. | `string` | n/a | yes |
+| log\_bucket | Log bucket to be used by Service Catalog Bucket | `string` | n/a | yes |
 | remote\_state\_bucket | Backend bucket to load remote state information from previous steps. | `string` | n/a | yes |
 
 ## Outputs

--- a/docs/assets/terraform/5-appinfra/service-catalog-infra-repo/ml_business_unit/shared/README.md
+++ b/docs/assets/terraform/5-appinfra/service-catalog-infra-repo/ml_business_unit/shared/README.md
@@ -4,7 +4,6 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | instance\_region | The region where compute instance will be created. A subnetwork must exists in the instance region. | `string` | n/a | yes |
-| log\_bucket | Log bucket to be used by Service Catalog Bucket | `string` | n/a | yes |
 | remote\_state\_bucket | Backend bucket to load remote state information from previous steps. | `string` | n/a | yes |
 
 ## Outputs


### PR DESCRIPTION
- Use custom service accounts for build triggers, this implies in creating a storage bucket and manually assigning permissions.
- Fix README.md step
- Create missing symbolic link `5-app-infra/projects/service-catalog/business_unit_3/shared/common.auto.tfvars`
- Fix variables file `5-app-infra/projects/service-catalog/common.auto.example.tfvars`

Reference: https://cloud.google.com/build/docs/cloud-build-service-account-updates